### PR TITLE
Update docker-compose.yml to have most upto date relay image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,7 +127,7 @@ services:
       - DATABASE_URL=postgres://postgres:sphinx@db.sphinx:5432/postgres?sslmode=disable
 
   alice:
-    image: sphinxlightning/sphinx-relay-test:latest
+    image: sphinxlightning/sphinx-relay:latest
     container_name: alice.sphinx
     restart: on-failure
     depends_on:
@@ -151,7 +151,7 @@ services:
       - 3001:3001
 
   bob:
-    image: sphinxlightning/sphinx-relay-test:latest
+    image: sphinxlightning/sphinx-relay:latest
     container_name: bob.sphinx
     restart: on-failure
     depends_on:
@@ -175,7 +175,7 @@ services:
       - 3002:3002
 
   carol:
-    image: sphinxlightning/sphinx-relay-test:latest
+    image: sphinxlightning/sphinx-relay:latest
     container_name: carol.sphinx
     restart: on-failure
     depends_on:


### PR DESCRIPTION
changing the image to `sphinxlightning/sphinx-relay` instead of `sphinxlightning/sphinx-relay-test` since he later is 6 months old and the former gets updated automatically on every release

up to date relay image
https://hub.docker.com/r/sphinxlightning/sphinx-relay/tags

out of date sphinx-relay-test image
https://hub.docker.com/r/sphinxlightning/sphinx-relay-test/tags