### PR TITLE
extra_host fix for linux

### DIFF
--- a/alts/no-alice.yml
+++ b/alts/no-alice.yml
@@ -151,6 +151,8 @@ services:
       - MEDIA_HOST=localhost:5555
     ports:
       - 3002:3002
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   carol:
     image: sphinxlightning/sphinx-relay
@@ -175,6 +177,8 @@ services:
       - MEDIA_HOST=localhost:5555
     ports:
       - 3003:3003
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   relaysetup:
     image: node:12-buster-slim

--- a/alts/no-tribes.yml
+++ b/alts/no-tribes.yml
@@ -140,6 +140,9 @@ services:
       - MEDIA_HOST=meme.sphinx:5555
     ports:
       - 3001:3001
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
 
   bob:
     image: sphinxlightning/sphinx-relay-test:latest
@@ -165,6 +168,8 @@ services:
       - MEDIA_HOST=meme.sphinx:5555
     ports:
       - 3002:3002
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   carol:
     image: sphinxlightning/sphinx-relay-test:latest
@@ -190,6 +195,8 @@ services:
       - MEDIA_HOST=meme.sphinx:5555
     ports:
       - 3003:3003
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   relaysetup:
     image: node:12-buster-slim

--- a/alts/proxy.yml
+++ b/alts/proxy.yml
@@ -166,6 +166,9 @@ services:
       - MEDIA_HOST=localhost:5555
     ports:
       - 3001:3001
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
 
   bob:
     image: sphinxlightning/sphinx-relay
@@ -191,6 +194,8 @@ services:
       - MEDIA_HOST=localhost:5555
     ports:
       - 3002:3002
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   carol:
     image: sphinxlightning/sphinx-relay
@@ -216,6 +221,8 @@ services:
       - MEDIA_HOST=localhost:5555
     ports:
       - 3003:3003
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   dave:
     image: sphinxlightning/sphinx-relay

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -151,6 +151,9 @@ services:
       - MEDIA_HOST=localhost:5555
     ports:
       - 3001:3001
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
 
   bob:
     image: sphinxlightning/sphinx-relay
@@ -176,6 +179,8 @@ services:
       - MEDIA_HOST=localhost:5555
     ports:
       - 3002:3002
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   carol:
     image: sphinxlightning/sphinx-relay
@@ -201,6 +206,8 @@ services:
       - MEDIA_HOST=localhost:5555
     ports:
       - 3003:3003
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   relaysetup:
     image: node:12-buster-slim


### PR DESCRIPTION
linux users were having issues running sphinx-stack on their local because `/etc/hosts` wasn't mapping host.docker.internal to their localhost this fixes this issue without having the user having to manually edit the `/etc/host` file