### PR TITLE
customize docker compose for local dev and update some aperture configs

### DIFF
--- a/alts/README.md
+++ b/alts/README.md
@@ -54,5 +54,21 @@ Some configs to look at for more customization:
 To run sphinx stack with aperture:
 
 ```
-docker-compose -f docker-compose.yml -f ./alts/lsat.yml --project-directory . up -d
+docker compose -f docker-compose.yml -f ./alts/lsat.yml --project-directory . up -d
 ```
+
+#### Local Development with Meme
+There is also a special service and profile in the main docker compose file
+that allows for running with a local development instance of a service. 
+By commenting out one of the `depends_on` services listed in the `exclude-services`
+service, everything but that service or services will be run. 
+
+Furthermore, by using `profiles` you can make services that will only run with that
+specific profile passed. For example, to run a local meme for developing against,
+comment out `meme` from the exclude-services list, and then run:
+
+```
+$  docker compose -f docker-compose.yml --profile aperture --project-directory . up exclude-services
+```
+
+Once your meme server is running and connected to the other services, everything should be working.

--- a/alts/lsat.yml
+++ b/alts/lsat.yml
@@ -28,3 +28,7 @@ services:
       - alice-lnd
     entrypoint: ["aperture", "--configfile=/aperture/aperture.yaml"]
 
+networks: 
+  default:
+    name: sphinx-stack
+    

--- a/aperture/aperture.yaml
+++ b/aperture/aperture.yaml
@@ -60,7 +60,7 @@ etcd:
 services:
   # The identifying name of the service. This will also be used to identify
   # which capabilities caveat (if any) corresponds to the service.
-  - name: "meme"
+  - name: "sphinx_meme"
 
     # The regular expression used to match the service host.
     hostregexp: "^localhost.*$"
@@ -84,12 +84,14 @@ services:
 
     # A comma-delimited list of capabilities that will be granted for tokens of
     # the service at the base tier.
-    # capabilities: "add,subtract"
+    capabilities: "large_upload"
 
     # The set of constraints that are applied to tokens of the service at the
     # base tier. Can also add these on the other side
-    # constraints:
-    #   "valid_until": "2022-12-31"
+    # should be of format of: [capability]_[constraint]_[constraint_unit] 
+    # with the unit being dependent on the actual constraint itself
+    constraints:
+      "large_upload_max_mb": "500"
 
     # The LSAT value in satoshis for the service. It is ignored if
     # dynamicprice.enabled is set to true.
@@ -97,9 +99,9 @@ services:
 
     # List of regular expressions for paths that don't require authentication
     authwhitelistpaths:
-      # generated negative match for "/file" using 
+      # generated negative match for "largefile" using 
       # https://www.formauri.es/personal/pgimeno/misc/non-match-regex 
-      - "^([^f]|f(f|i(f|lf))*([^fi]|i([^fl]|l[^ef])))*(f(f|i(f|lf))*(il?)?)?$"
+      - "^([^l]|l(l|a(l|r(l|g(l|e(l|f(l|il(argefil)*(l|a(l|r(l|g(l|e(l|fl)))))))))))*([^al]|a([^lr]|r([^gl]|g([^el]|e([^fl]|f([^il]|i([^l]|l(argefil)*([^ael]|a([^lr]|r([^gl]|g([^el]|e([^fl]|f([^il]|i[^l]))))))))))))))*(l(l|a(l|r(l|g(l|e(l|f(l|il(argefil)*(l|a(l|r(l|g(l|e(l|fl)))))))))))*(a((r(g?|ge(fi?)?))?|rgefil(argefil)*(a(r(g?|ge(fi?)?))?)?))?)?$"
 
 # Settings for a Tor instance to allow requests over Tor as onion services.
 # Configuring Tor is optional.

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -3,7 +3,8 @@ version: "3"
 services:
   meme:
     # in some environments, like alt/lsat.yml, we don't want
-    # to expose the meme server to the outside world. This will
+    # to expose the meme server to the outside world because we need
+    # requests to go through the aperture proxy first. This will
     # add this mapping to the default configuration, but allows
     # the meme server configs in the lsat setup to not expose them.
     # see here for more details: https://mindbyte.nl/2018/04/04/overwrite-ports-in-docker-compose.html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,7 +126,7 @@ services:
       - LOCAL_ENCRYPTION_KEY=88303a55f5829d9e35936364204bcb007fe330db649902fa1085a7bce3732347
       - HOST=localhost:5555
       - DATABASE_URL=postgres://postgres:sphinx@db.sphinx:5432/postgres?sslmode=disable
-
+  
   alice:
     image: sphinxlightning/sphinx-relay
     container_name: alice.sphinx
@@ -215,3 +215,63 @@ services:
     volumes:
       - ./relay:/relay
       - ./relay/nodes_partial/nodes_partial.json:/relay/nodes_partial.json
+
+  etcd:
+    image: "quay.io/coreos/etcd"
+    container_name: etcd.sphinx
+    profiles:
+      - aperture
+    environment:
+      - ETCD_ADVERTISE_CLIENT_URLS=http://etcd.sphinx:2379
+      - ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379
+    command: "etcd -name etcd-meme-aperture"
+
+  aperture:
+    image: "lightninglabs/aperture:v0.1.12-beta"
+    container_name: aperture.sphinx
+    profiles:
+      - aperture
+    ports:
+      # for now we will have aperture run on the default meme port
+      # so that it's easier to use this as a drop in replacement for any existing setups
+      - 5555:8081
+    volumes:
+      - ./aperture:/aperture
+      # using alice's lnd node as the backend for aperture
+      - ./lnd/alice/.lnd:/lnd
+    # want to restart on failure b/c the lightning node needs to be
+    # fully operational so that aperture can connect to it and successfully start
+    restart: on-failure
+    depends_on:
+      - etcd
+      - alice-lnd
+    entrypoint: ["aperture", "--configfile=/aperture/aperture.yaml"]
+    
+  # an override service that runs everything in the
+  # depends_on list. Comment out to use overrides
+  exclude-services:
+    image: nginx
+    command: echo done
+    depends_on:
+      - bitcoind
+      - alice-lnd
+      - bob-lnd
+      - carol-lnd
+      - lndsetup
+      - db
+      - tribes
+      - auth
+      - mqtt
+      # - meme
+      - alice
+      - bob
+      - carol
+      - relaysetup
+      - aperture
+      - etcd
+    profiles:
+      - aperture
+  
+networks: 
+  default:
+    name: sphinx-stack


### PR DESCRIPTION
As I started to think about implementing the new routes in meme server for lsat support ([6](https://github.com/stakwork/sphinx-meme/pull/6), and [7](https://github.com/stakwork/sphinx-meme/pull/7)) I wanted to come up with a way to easily integrate the local development code in the rest of the sphinx stack. 

The custom `no-alice` configs approach seemed like it would get unwieldy if we did it for every piece of the stack we needed to develop against and would get complicated if we ever made a change to the base docker compose configs. 

This approach combines a few different strategies to allow for selective service enabling while allowing for services in external docker-compose files to integrate: 

- uses a kind of "container" service that sets all services you want to run in the `depend_on` property. This will start up all services in that list and so you can comment out any you don't want to run. Still manual but hopefully a little easier to maintain
- [docker compose profiles](https://docs.docker.com/compose/profiles/) - because an lsat-enabled stack needs two extra services AND needs to route requests differently than in a normal stack, setting `profiles` to only run these services when you want to run `aperture` makes this more configurable. The default `docker compose up`  will skip any services that have explicit `profiles` and to run the special aperture services, you set that profile in the CLI `--profile aperture` 
- Because the meme server still needs to network with these containers, I added an explicitly named network that could be declared from the meme server's docker compose. 

So, to run an lsat-enabled sphinx stack with a local development instance of meme server, all you now have to do is comment out `meme` from the list of services in the `exclude-services` service in `docker-compose` and then run:

```
docker compose --profile aperture up exclude-services
```

If we like this approach, it could probably be tested to use with the other `alts`.  I'm pretty sure this could completely replace the lsat.yaml one. 

I'm also open to renaming the service(s), profiles, etc. based on how you all imagine this being most useful,  so feel free to comment on those. 