### PR TITLE
Update aperture configs for expiration

### DIFF
--- a/alts/README.md
+++ b/alts/README.md
@@ -50,7 +50,8 @@ Some configs to look at for more customization:
 - `authenticator` - lightning node configurations including host and where credentials can be found
 - `services` - a list of services that will be protected by aperture.
   These have other options that can be used to customize the endpoint and protection conditions
-
+- `services.price` to change the price for access to meme server 
+- `services.timeout` to change the relative expiration for lsats minted by aperture.
 To run sphinx stack with aperture:
 
 ```

--- a/alts/lsat.yml
+++ b/alts/lsat.yml
@@ -10,7 +10,8 @@ services:
     command: "etcd -name etcd-meme-aperture"
 
   aperture:
-    image: "lightninglabs/aperture:v0.1.12-beta"
+    # image: "lightninglabs/aperture:v0.1.12-beta"
+    image: "bucko/aperture:timeout"
     container_name: aperture.sphinx
     ports:
       # for now we will have aperture run on the default meme port

--- a/aperture/aperture.yaml
+++ b/aperture/aperture.yaml
@@ -95,7 +95,7 @@ services:
 
     # The LSAT value in satoshis for the service. It is ignored if
     # dynamicprice.enabled is set to true.
-    price: 10
+    price: 25000
 
     # List of regular expressions for paths that don't require authentication
     authwhitelistpaths:

--- a/aperture/aperture.yaml
+++ b/aperture/aperture.yaml
@@ -92,11 +92,10 @@ services:
     # with the unit being dependent on the actual constraint itself
     constraints:
       "large_upload_max_mb": "500"
-      # a caveat will be added that expires the LSAT
-      # after this many seconds, 31557600 = 1 year.
-      # This value is on the lsat as well as the time created,
-      # which can allow the validator to know when the lsat has expired
-      "large_upload_valid_for_seconds": "31557600"
+
+    # a caveat will be added that expires the LSAT
+    # after this many seconds, 31557600 = 1 year.
+    timeout: 31557600
 
     # The LSAT value in satoshis for the service. It is ignored if
     # dynamicprice.enabled is set to true.

--- a/aperture/aperture.yaml
+++ b/aperture/aperture.yaml
@@ -92,6 +92,11 @@ services:
     # with the unit being dependent on the actual constraint itself
     constraints:
       "large_upload_max_mb": "500"
+      # a caveat will be added that expires the LSAT
+      # after this many seconds, 31557600 = 1 year.
+      # This value is on the lsat as well as the time created,
+      # which can allow the validator to know when the lsat has expired
+      "large_upload_valid_for_seconds": "31557600"
 
     # The LSAT value in satoshis for the service. It is ignored if
     # dynamicprice.enabled is set to true.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -234,7 +234,10 @@ services:
     command: "etcd -name etcd-meme-aperture"
 
   aperture:
-    image: "lightninglabs/aperture:v0.1.12-beta"
+    # image: "lightninglabs/aperture:v0.1.12-beta"
+    # hopefully this is a temporary replacement to use the new aperture
+    # support for a timeout caveat
+    image: "bucko/aperture:timeout"
     container_name: aperture.sphinx
     profiles:
       - aperture


### PR DESCRIPTION
This updates the default aperture config for a higher price for large file uploads and adds a timeout value for aperture to add expirations to the lsats it mints. 

Unfortunately, aperture doesn't support this kind of relative timeout currently. There is a [PR up for aperture](https://github.com/lightninglabs/aperture/pull/81) to support this feature so it is currently unstable as the API might change. But I published a custom docker image which this PR references in its docker compose files to leverage for preliminary use. 