### PR TITLE
increased number of proxy users

### DIFF
--- a/relay/dave.json
+++ b/relay/dave.json
@@ -26,7 +26,7 @@
   "gitactionenv": {
     "hub_api_url": "None",
     "proxy_initial_sats": 20000,
-    "proxy_new_nodes": 2,
+    "proxy_new_nodes": 4,
     "proxy_lnd_ip": "proxy.sphinx",
     "proxy_admin_token": "r46bnf8ibrhbb424heba",
     "proxy_admin_url": "http://proxy.sphinx:5050",


### PR DESCRIPTION
This just makes it so the automated test generate 3 proxy users instead of just one.

This doesn't not solve and tests that require users at startup, since this will generate them one by one when the test suite is setup